### PR TITLE
Verify go fmt output is empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,20 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Format
-      run: go fmt ./...
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
 
-    - name: Build
-      run: go build -v ./...
+    - name: Go Format
+      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.17.x'
+      run: test -z "$(go fmt ./...)"
+
+    - name: Go Vet
+      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.17.x'
+      run: test -z "$(go vet ./...)"
 
     - name: Test
       run: go test -v ./...
+
+    - name: Build
+      run: go build -v ./...


### PR DESCRIPTION
Continuing our discussion from #21, this throws errors if `go fmt` or `go vet` return any issues when building on the latest version of Go on Ubuntu (I've left the tests off other versions in case `go fmt` has any formatting updates on different releases).

Related to #16 

Signed-off-by: Brandon Mitchell <git@bmitch.net>